### PR TITLE
Support for robocopy's /XD argument

### DIFF
--- a/include/EACopyClient.h
+++ b/include/EACopyClient.h
@@ -28,6 +28,7 @@ struct ClientSettings
 	StringList			filesOrWildcardsFiles;
 	StringList			filesExcludeFiles;
 	StringList			excludeWildcards;
+	StringList			excludeWildcardDirectories;
 	StringList			optionalWildcards; // Will not causes error if source file fulfill optionalWildcards
 	uint				threadCount					= 0;
 	uint				retryWaitTimeMs				= 30 * 1000;

--- a/source/EACopy.cpp
+++ b/source/EACopy.cpp
@@ -39,6 +39,7 @@ void printHelp()
 	logInfoLinef(L"                      options to add additional params. /PURGE only supported");
 	logInfoLinef(L"/IX file [file]... :: same as /I but excluding files/directories instead.");
 	logInfoLinef();
+	logInfoLinef(L"/XD dir [dir]...   :: eXclude Directories matching given names/paths/wildcards.");
 	logInfoLinef(L"/XF file [file]... :: eXclude Files matching given names/paths/wildcards.");
 	logInfoLinef(L"/OF file [file]... :: Optional Files matching given names/paths/wildcards.");
 	logInfoLinef();
@@ -202,6 +203,10 @@ bool readSettings(Settings& outSettings, int argc, wchar_t* argv[])
 		{
 			activeCommand = L"XF";
 		}
+		else if (startsWithIgnoreCase(arg, L"/XD"))
+		{
+			activeCommand = L"XD";
+		}
 		else if (startsWithIgnoreCase(arg, L"/OF"))
 		{
 			activeCommand = L"OF";
@@ -289,6 +294,10 @@ bool readSettings(Settings& outSettings, int argc, wchar_t* argv[])
 			else if (equalsIgnoreCase(activeCommand, L"XF"))
 			{
 				outSettings.excludeWildcards.push_back(arg);
+			}
+			else if (equalsIgnoreCase(activeCommand, L"XD"))
+			{
+				outSettings.excludeWildcardDirectories.push_back(arg);
 			}
 			else if (equalsIgnoreCase(activeCommand, L"OF"))
 			{

--- a/source/EACopyClient.cpp
+++ b/source/EACopyClient.cpp
@@ -567,6 +567,11 @@ Client::handleFile(const WString& sourcePath, const WString& destPath, const wch
 bool
 Client::handleDirectory(const WString& sourcePath, const WString& destPath, const wchar_t* directory, const wchar_t* wildcard, int depthLeft, const HandleFileFunc& handleFileFunc, ClientStats& stats)
 {
+	// Chec if dir should be excluded because of wild cards
+	for (auto& excludeWildcard : m_settings.excludeWildcardDirectories)
+		if (PathMatchSpecW(directory, excludeWildcard.c_str()))
+			return true;
+
 	WString newSourceDirectory = sourcePath + directory + L'\\';
 	WString newDestDirectory = destPath;
 	if (!m_settings.flattenDestination && *directory)


### PR DESCRIPTION
/XD excludes matches only on Directories, which is
helpful in avoiding temporary directories (e.g. the
"Intermediate", "DerivedDataCache" and "Saved" when
using EACopy with Unreal Engine)

This is better than using "/XF *\name\*" because it
really ignores these directories instead of creating
empty directories in the target path. Also, it matches
robocopy's command line arguments.