### PR TITLE
Fix /MIR when using server connection

### DIFF
--- a/include/EACopyClient.h
+++ b/include/EACopyClient.h
@@ -134,6 +134,7 @@ private:
 	bool				ensureDirectory(const wchar_t* directory);
 	const wchar_t*		getRelativeSourceFile(const WString& sourcePath) const;
 	Connection*			createConnection(const wchar_t* networkPath, bool isMainConnection, ClientStats& stats, bool& failedToConnect);
+	bool				isIgnoredDirectory(const wchar_t* directory);
 
 
 	// Settings

--- a/source/EACopyClient.cpp
+++ b/source/EACopyClient.cpp
@@ -1040,7 +1040,7 @@ Client::purgeFilesInDirectory(const WString& path, int depthLeft)
 
 	// If there is a connection and no files were handled inside the directory we can just do a full delete on the server side
 	if (m_destConnection)
-		if ((relPath.empty() && m_handledFiles.empty()) || m_handledFiles.find(relPath) == m_handledFiles.end())
+		if ((relPath.empty() && m_handledFiles.empty()) || (!relPath.empty() && (m_handledFiles.find(relPath) == m_handledFiles.end())))
 			return m_destConnection->sendDeleteAllFiles(relPath.c_str());
 
 

--- a/source/EACopyClient.cpp
+++ b/source/EACopyClient.cpp
@@ -567,10 +567,8 @@ Client::handleFile(const WString& sourcePath, const WString& destPath, const wch
 bool
 Client::handleDirectory(const WString& sourcePath, const WString& destPath, const wchar_t* directory, const wchar_t* wildcard, int depthLeft, const HandleFileFunc& handleFileFunc, ClientStats& stats)
 {
-	// Chec if dir should be excluded because of wild cards
-	for (auto& excludeWildcard : m_settings.excludeWildcardDirectories)
-		if (PathMatchSpecW(directory, excludeWildcard.c_str()))
-			return true;
+	if (isIgnoredDirectory(directory))
+ 		return true;
 
 	WString newSourceDirectory = sourcePath + directory + L'\\';
 	WString newDestDirectory = destPath;
@@ -1070,6 +1068,8 @@ Client::purgeFilesInDirectory(const WString& path, int depthLeft)
 
 		if (m_handledFiles.find(filePath) == m_handledFiles.end())
 		{
+			if (isIgnoredDirectory(fd.cFileName))
+				continue;
 			WString fullPath = (path + L'\\' + fd.cFileName);
 	        if(isDir)
 			{
@@ -1317,6 +1317,16 @@ Client::createConnection(const wchar_t* networkPath, bool isMainConnection, Clie
 	connectionGuard.cancel();
 
 	return connection;
+}
+
+bool
+Client::isIgnoredDirectory(const wchar_t *directory)
+{
+	// Check if dir should be excluded because of wild cards
+	for (auto& excludeWildcard : m_settings.excludeWildcardDirectories)
+		if (PathMatchSpecW(directory, excludeWildcard.c_str()))
+			return true;
+	return false;
 }
 
 Client::Connection::Connection(const ClientSettings& settings, ClientStats& stats, SOCKET s)


### PR DESCRIPTION
When purging files over a server connection, the first call to
purgeFilesInDirectory is to the root directory (EACopyClient, line 175).
There, the relPath is "". If there is a connection to the server, the
early return condition in line 1042 kicks in, since that directory "" is
never in m_handledFiles.

Apparently, the second part of the if-clause in 1043 is meant for
purging specific directories via "/PURGE xxx", so it needs to be
protected for the root-directory (aka "").

Repro-case of the bug:

- start EACopyService
- create a folder, e.g. "C:\asd"
- create a shared folder, e.g. "C:\share" and share it to network
- call "EACopy /MIR /SERVER c:\asd \\mypcname\share" (of course,
  assuming your pc is called "mypcname" and the share is called "share")
- observe that nothing is copied into C:\share