### PR TITLE
/XD will ignore target directories when using /MIR

### DIFF
--- a/include/EACopyClient.h
+++ b/include/EACopyClient.h
@@ -134,6 +134,7 @@ private:
 	bool				ensureDirectory(const wchar_t* directory);
 	const wchar_t*		getRelativeSourceFile(const WString& sourcePath) const;
 	Connection*			createConnection(const wchar_t* networkPath, bool isMainConnection, ClientStats& stats, bool& failedToConnect);
+	bool				isIgnoredDirectory(const wchar_t* directory);
 
 
 	// Settings

--- a/source/EACopyClient.cpp
+++ b/source/EACopyClient.cpp
@@ -567,10 +567,8 @@ Client::handleFile(const WString& sourcePath, const WString& destPath, const wch
 bool
 Client::handleDirectory(const WString& sourcePath, const WString& destPath, const wchar_t* directory, const wchar_t* wildcard, int depthLeft, const HandleFileFunc& handleFileFunc, ClientStats& stats)
 {
-	// Chec if dir should be excluded because of wild cards
-	for (auto& excludeWildcard : m_settings.excludeWildcardDirectories)
-		if (PathMatchSpecW(directory, excludeWildcard.c_str()))
-			return true;
+	if (isIgnoredDirectory(directory))
+ 		return true;
 
 	WString newSourceDirectory = sourcePath + directory + L'\\';
 	WString newDestDirectory = destPath;
@@ -1070,6 +1068,8 @@ Client::purgeFilesInDirectory(const WString& path, int depthLeft)
 
 		if (m_handledFiles.find(filePath) == m_handledFiles.end())
 		{
+			if (isIgnoredDirectory(fd.cFileName))
+				continue;
 			WString fullPath = (path + L'\\' + fd.cFileName);
 	        if(isDir)
 			{
@@ -1317,6 +1317,16 @@ Client::createConnection(const wchar_t* networkPath, bool isMainConnection, Clie
 	connectionGuard.cancel();
 
 	return connection;
+}
+
+bool
+Client::isIgnoredDirectory(const wchar_t *directory)
+{
+	// Check if dir should be excluded because of wild cards
+	for (auto& excludeWildcard : m_settings.excludeWildcardDirectories)
+		if (PathMatchSpecW(directory, excludeWildcard.c_str()))
+			return true;
+	return false;
 }
 
 Client::Connection::Connection(const ClientSettings& settings, ClientStats& stats, SOCKET s)


### PR DESCRIPTION
For vanilla robocopy, the /XD also ignores directories
in the target folder when purging files via /MIR or
/PURGE, so do the same for EACopy.

(This is especially useful to not remove temporary
directories like .git or .vs)

Note, that subdirectories ARE purged if their parent
folder is purged, so if you have foo/bar/baz and specify
/XD baz, but either foo or bar is not part of the source,
then baz will get deleted. This is the same behaviour
as for robocopy.

(cherry picked from commit fda73650e8d3cc68d429c59d0d038c65844e5848)