### PR TITLE
Feature/fix logic issue with wild card parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@
 #IDE settings
 .vscode/
 .vs/
+CMakeSettings.json
 
 #Exclude files in the config directories
 Release/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,5 +51,6 @@ target_link_libraries(EACopyService zstd)
 
 
 if(EACOPY_BUILD_TESTS)
+	include(CTest)
 	add_subdirectory(test)
 endif()

--- a/README.md
+++ b/README.md
@@ -65,14 +65,31 @@ As an example, look at the "build.bat" file in the scripts folder for how to bui
 @mkdir build
 @pushd build
 
-@call cmake .. -G "Visual Studio 15 2017 Win64" -DEACOPY_BUILD_TESTS:BOOL=ON 
+@call cmake .. -G "Visual Studio 15 2017 Win64" -DEACOPY_BUILD_TESTS:BOOL=ON
+rem @call cmake .. -G "Visual Studio 16 2019" -A x64 -DEACOPY_BUILD_TESTS:BOOL=ON
 @call cmake --build . --config Release
+@call cmake --build . --config Debug
 
 @pushd test
 @call ctest -C Release -V
+@call ctest -C Debug
 
 @popd
 @popd
+
+```
+
+#CI System
+Travis CI for EACopy: https://travis-ci.org/github/electronicarts/EACopy
+
+## Test Setup
+The test/CMakeLists.txt file might have its tests commented out. If so go to the file and uncomment the test line (as below):
+
+```
+# Use CTest
+enable_testing()
+#Disabled on farm. Enable this for local testing
+add_test(EACopyTestRun EACopyTest)
 ```
 
 ## Running the Tests
@@ -89,12 +106,30 @@ EACopyTest D:\EACopyTest\source \\localhost\EACopyTest\dest
 ```
 
 Another way to set this up for ease of local development is to set these defines in the top of EACopyTest.cpp to the source and dest folders you have setup:
+* Default setting for these values is L""; (Make sure you change the values or You will get an error that you didnt specify the source/dir arguments)
+
 ```
 #define DEFAULT_SOURCE_DIR  L"D:\\\\EACopyTest\\source"
 #define DEFAULT_DEST_DIR  L"\\\\localhost\\EACopyTest\\dest" // local share to D:\EACopyTest\dest
 ```
 
 You can then set EACopyTest as your startup project in Visual Studio and debug from there, or just run EACopyTest.exe from the cmdline without parameters and it will use those folders set in the code.
+
+## Setting up CMake with Visual Studio for Debugging
+Notes: 
+ - You need to run Visual Studio as Admin to properly run some tests
+ - Once set up make sure to set the CMake settings so EACOPY_BUILD_TESTS is set to true so the tests are generated also.
+Reference documentation for setting up CMake: https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019
+Reference documenation for running ctests in VS: https://docs.microsoft.com/en-us/visualstudio/test/how-to-use-ctest-for-cpp?view=vs-2019
+
+
+##Reference links
+CMake main page: https://cmake.org/
+CTest documentation page: https://cmake.org/cmake/help/latest/manual/ctest.1.html
+Basic CMake intro: https://a4z.bitbucket.io/blog/2018/05/17/Speed-up-your-test-cycles-with-CMake.html
+CMake Tutorial 1: https://cliutils.gitlab.io/modern-cmake/chapters/testing.html
+CMake Tutorial 2: https://bastian.rieck.me/blog/posts/2017/simple_unit_tests/
+CMake File example: https://riptutorial.com/cmake/example/14698/basic-test-suite
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Your pull request should:
 EACopy uses the defacto standard CMake build system.
 
 As an example, look at the "build.bat" file in the scripts folder for how to build the library and build/run the unit tests.
-
+NOTE: to run ctest you need to run the CLI you use as Administrator!
 ```
 <start at the project root>
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Your pull request should:
 EACopy uses the defacto standard CMake build system.
 
 As an example, look at the "build.bat" file in the scripts folder for how to build the library and build/run the unit tests.
-NOTE: to run ctest you need to run the CLI you use as Administrator!
+NOTE: to run ctest you need to run the CLI you use as Administrator! Also you must make the changes outlined in "Test Setup" and "Running the Tests" sections below.
 ```
 <start at the project root>
 

--- a/source/EACopy.cpp
+++ b/source/EACopy.cpp
@@ -106,7 +106,7 @@ bool readSettings(Settings& outSettings, int argc, wchar_t* argv[])
 			}
 			copySubdirectories = true;
 			if (outSettings.copySubdirDepth == 0)
-				outSettings.copySubdirDepth = 1000000;
+				outSettings.copySubdirDepth = 10000;
 		}
 		else if (equalsIgnoreCase(arg, L"/E"))
 		{
@@ -118,7 +118,7 @@ bool readSettings(Settings& outSettings, int argc, wchar_t* argv[])
 			copySubdirectories = true;
 			outSettings.copyEmptySubdirectories = true;
 			if (outSettings.copySubdirDepth == 0)
-				outSettings.copySubdirDepth = 1000000;
+				outSettings.copySubdirDepth = 10000;
 		}
 		else if (startsWithIgnoreCase(arg, L"/LEV:"))
 		{
@@ -140,7 +140,7 @@ bool readSettings(Settings& outSettings, int argc, wchar_t* argv[])
 		else if (equalsIgnoreCase(arg, L"/MIR"))
 		{
 			outSettings.purgeDestination = true;
-			outSettings.copySubdirDepth = 1000000;
+			outSettings.copySubdirDepth = 10000;
 			outSettings.copyEmptySubdirectories = true;
 			copySubdirectories = true;
 		}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(EACopyTest CXX)
 
+include(CTest)
 
 #-------------------------------------------------------------------------------------------
 # Executable definition
@@ -32,5 +33,7 @@ target_link_libraries(EACopyTest zstd)
 # Run Unit tests and verify the results.
 #-------------------------------------------------------------------------------------------
 
-#include(CTest)
-#add_test(EACopyTestRuns EACopyTest)
+# Use CTest
+enable_testing()
+#Disabled on farm. Enable this for local testing
+#add_test(EACopyTestRun EACopyTest)

--- a/test/EACopyTest.cpp
+++ b/test/EACopyTest.cpp
@@ -15,8 +15,15 @@ namespace eacopy
 	#define EACOPY_ASSERT(x) assert(x)
 #endif
 
-#define DEFAULT_SOURCE_DIR  L"" // L"C:\\temp\\EACopyTest\\source"
-#define DEFAULT_DEST_DIR  L"" // L"\\\\localhost\\EACopyTest\\dest" // local share to C:\temp\EACopyTest\dest
+//Set these Variables to run EACopyTest without having to specify the source/dest input parameters.
+//Examples are detailed:
+// L"C:\\temp\\EACopyTest\\source" OR L"I:\\MyLocalDrive"
+// This directory should exist.
+#define DEFAULT_SOURCE_DIR  L"" 
+// L"\\\\localhost\\EACopyTest\\dest" OR L"\\\\localhost\\MyShare"
+// Locally configured share to C:\temp\EACopyTest\dest OR I:\MyShare
+//The real directory should exist and the share setup to point to the directory.
+#define DEFAULT_DEST_DIR  L""
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -196,6 +203,13 @@ struct TestBase
 		CloseHandle(file);
 
 		m_setupTime += getTimeMs() - startSetupTime;
+	}
+
+	bool getGeneralFileExists(const wchar_t* fullFilePath)
+	{
+		WString str = L"";
+		str.append(fullFilePath);
+		return PathFileExistsW(str.c_str()) == TRUE;
 	}
 
 	bool getTestFileExists(const wchar_t* name, bool source = false)
@@ -893,6 +907,7 @@ EACOPY_TEST(CopyFileTargetHasSymlink)
 
 EACOPY_TEST(CopyFileWithVeryLongPath)
 {
+	//This test when run in Visual Studio must be have Visual Studio run as Administrator!
 	WString longPath;
 	for (uint i=0;i!=30; ++i)
 		longPath.append(L"TestFolder\\");
@@ -1392,6 +1407,29 @@ EACOPY_TEST(CopyFileWithDoubleSlashPath2)
 	EACOPY_ASSERT(destFile.fileSize == fileSize);
 }
 
+EACOPY_TEST(CopyFileWithExplicitWildCardExtensionUnderDirectories)
+{
+	uint fileSize = 3 * 1024 * 1024 + 123;
+	createTestFile(L"Test\\Foo.txt", fileSize);
+	createTestFile(L"Bar.txt", 100);
+	createTestFile(L"Test2\\Foo2.txt", 1000);
+
+	ClientSettings clientSettings(getDefaultClientSettings(L"*.txt"));
+	clientSettings.copySubdirDepth = 100;
+	Client client(clientSettings);
+	EACOPY_ASSERT(client.process(clientLog) == 0);
+
+	FileInfo destFile;
+	EACOPY_ASSERT(getFileInfo(destFile, (testDestDir + L"\\Test\\Foo.txt").c_str()) != 0);
+	EACOPY_ASSERT(destFile.fileSize == fileSize);
+
+	EACOPY_ASSERT(getFileInfo(destFile, (testDestDir + L"\\Bar.txt").c_str()) != 0);
+	EACOPY_ASSERT(destFile.fileSize == 100);
+
+	EACOPY_ASSERT(getFileInfo(destFile, (testDestDir + L"\\Test2\\Foo2.txt").c_str()) != 0);
+	EACOPY_ASSERT(destFile.fileSize == 1000);
+}
+
 #if defined(EACOPY_ALLOW_DELTA_COPY_SEND)
 EACOPY_TEST_LOOP(ServerCopyMediumFileDelta, 3)
 {
@@ -1642,6 +1680,7 @@ EACOPY_TEST(ServerTestMemory)
 EACOPY_TEST(UsedByOtherProcessError)
 {
 	wchar_t buffer[1024];
+	wchar_t buffer2[1024];
 	DWORD size = GetCurrentDirectoryW(1024, buffer);
 
 	#if !defined(NDEBUG)
@@ -1649,6 +1688,13 @@ EACOPY_TEST(UsedByOtherProcessError)
 	#else
 	wcscat(buffer, L"\\..\\Release\\");
 	#endif
+	//Handle case for debugging in Visual Studio. Executable path is at ..\\ level (not under Debug or Release)
+	wcsncpy(buffer2, buffer, 1024);
+	wcscat(buffer2, L"eacopy.exe");
+	if (!(getGeneralFileExists(buffer2) == true))
+	{
+		wcscat(buffer, L"..\\");
+	}
 
 	ClientSettings clientSettings;
 	clientSettings.sourceDirectory += buffer;
@@ -1693,7 +1739,6 @@ EACOPY_TEST(PathGoingOverMaxPath)
 	EACOPY_ASSERT(client.process(clientLog) == 0);
 	EACOPY_ASSERT(isEqual((testSourceDir + L"Foo.txt").c_str(), (clientSettings.destDirectory + L"Foo.txt").c_str()));
 }
-
 
 
 void printHelp()


### PR DESCRIPTION
Pull Request to resolve an issue found when specifying Wild Cards such as *.txt rather than using the default (Which is *.*). The issue was that when using the wild card file input, the code was not copying anything over in sub directories. Test was added to verify this.

The changes below also clarify some of the workflow as well as provide information for debugging in Visual Studio and make some other small fixes.

Changes:
* Primary logic update: Change logic for main handleFilesInDirectory class. Previous logic assumed wild card of *.*. Now we check files first, then we go through all folders if we should.
* Update CMakeLists file with include(CTest) if Tests are set to true
* Update Test CMakeLists file to also include(Ctest) in case as well as add enable_testing() command as required. Add a comment regarding the fact that the tests are disabled
* Update README with more setup information and extra details
* Update the copySubdirDepth value to a more realistic 10000 (May wish to reduce to 1000 even)
* Update EACopyTest wth extra support functions and add a comment where the default dir variables are set.
* Add a new test for specific wildcard and add some comments in file
* Fixed UsedByOtherProcessError test to work through Visual Studio
* Added comments for DEFAULT_SOURCE_DIR and DEFAULT_DEST_DIR in EACopyTest.cpp
* Update .gitignore to ignore CMakeSettings.json which is setup when VS is setup for your CMake project