### PR TITLE
Further updates to handle when *.<extension> files are not in a directory when wild cards explicitly set

### DIFF
--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -28,7 +28,7 @@ Option | Description
 ```/I file [file]...``` | Use text file containing files/directories/wildcards. A line can also add dest to explicitly write dest and options to add additional params. /PURGE only supported  
 ```/IX file [file]...``` | Same as /I but excluding files/directories instead
 ```/XF file [file]...``` | Exclude Files matching given names/paths/wildcards  
-```/OF file [file]...``` | Optional Files matching given names/paths/wildcards  
+```/OF file [file]...``` | Optional Files matching given names/paths/wildcards  Only Used for FileList
 ```/MT[:n]``` | Do multi-threaded copies with n threads (default 8), n must be at least 1 and not greater than 128  
 ```/NOSERVER``` | Will not try to connect to Server  
 ```/SERVER``` | Must connect to Server. Fails copy if not succeed

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -28,7 +28,7 @@ Option | Description
 ```/I file [file]...``` | Use text file containing files/directories/wildcards. A line can also add dest to explicitly write dest and options to add additional params. /PURGE only supported  
 ```/IX file [file]...``` | Same as /I but excluding files/directories instead
 ```/XF file [file]...``` | Exclude Files matching given names/paths/wildcards  
-```/OF file [file]...``` | Optional Files matching given names/paths/wildcards  Only Used for FileList
+```/OF file [file]...``` | Optional Files matching given names/paths/wildcards Only used for FileLists.
 ```/MT[:n]``` | Do multi-threaded copies with n threads (default 8), n must be at least 1 and not greater than 128  
 ```/NOSERVER``` | Will not try to connect to Server  
 ```/SERVER``` | Must connect to Server. Fails copy if not succeed

--- a/source/EACopy.cpp
+++ b/source/EACopy.cpp
@@ -41,7 +41,7 @@ void printHelp()
 	logInfoLinef();
 	logInfoLinef(L"/XD dir [dir]...   :: eXclude Directories matching given names/paths/wildcards.");
 	logInfoLinef(L"/XF file [file]... :: eXclude Files matching given names/paths/wildcards.");
-	logInfoLinef(L"/OF file [file]... :: Optional Files matching given names/paths/wildcards.");
+	logInfoLinef(L"/OF file [file]... :: Optional Files matching given names/paths/wildcards. Only used for FileLists.");
 	logInfoLinef();
 	logInfoLinef(L"           /MT[:n] :: do multi-threaded copies with n threads (default 8).");
 	logInfoLinef(L"                      n must be at least 1 and not greater than 128.");

--- a/test/EACopyTest.cpp
+++ b/test/EACopyTest.cpp
@@ -1413,6 +1413,8 @@ EACOPY_TEST(CopyFileWithExplicitWildCardExtensionUnderDirectories)
 	createTestFile(L"Test\\Foo.txt", fileSize);
 	createTestFile(L"Bar.txt", 100);
 	createTestFile(L"Test2\\Foo2.txt", 1000);
+	//Verify files not matching wild card are just skipped when wild cards are used. Does not apply to using FileList
+	createTestFile(L"Test3\\NotFoo.xml", 100);
 
 	ClientSettings clientSettings(getDefaultClientSettings(L"*.txt"));
 	clientSettings.copySubdirDepth = 100;
@@ -1428,6 +1430,8 @@ EACOPY_TEST(CopyFileWithExplicitWildCardExtensionUnderDirectories)
 
 	EACOPY_ASSERT(getFileInfo(destFile, (testDestDir + L"\\Test2\\Foo2.txt").c_str()) != 0);
 	EACOPY_ASSERT(destFile.fileSize == 1000);
+
+	EACOPY_ASSERT(getFileInfo(destFile, (testDestDir + L"\\Test3\\NotFoo.xml").c_str()) == 0);
 }
 
 #if defined(EACOPY_ALLOW_DELTA_COPY_SEND)


### PR DESCRIPTION
* Added extra information for /OF flag being only used with filelists
* Updated logic for usecase where setting non * . * wild cards like *.txt not erroring when going through all directories. If file is explicit though it will error as it did before
* Added some extra test logic for verification as well as minor comments for new test info